### PR TITLE
Add doc structure for subsections

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,7 +2,7 @@ baseURL = "/"
 
 languageCode = "en-us"
 DefaultContentLanguage = "en"
-title = "nteract User Guide"
+title = "nteract Documentation"
 theme = "docdock"
 themesdir = "themes"
 pygmentsCodeFences = true
@@ -55,11 +55,11 @@ weight = 11
 
 [[menu.shortcuts]]
 name = "<i class='fa fa-bookmark'></i> <label>nteract Site</label>"
-identifier = "hugodoc"
+identifier = "nteractsite"
 url = "https://nteract.io/"
 weight = 20
 
 [[menu.shortcuts]]
 name = "<i class='fa fa-bullhorn'></i> <label>Credits</label>"
-url = "/credits"
+url = "https://nteract.io/about"
 weight = 30

--- a/config.toml
+++ b/config.toml
@@ -43,7 +43,7 @@ home = [ "HTML", "RSS", "JSON"]
 
 [[menu.shortcuts]]
 pre = "<h3>More</h3>"
-name = "<i class='fa fa-github'></i> <label>Github repo</label>"
+name = "<i class='fa fa-github'></i> <label>GitHub repo</label>"
 identifier = "ds"
 url = "https://github.com/nteract/user-guide/"
 weight = 10

--- a/content/README.md
+++ b/content/README.md
@@ -1,8 +1,0 @@
-This should include:
-
-* Markdown files
-* Notebooks!
-
-📝 Keep your filenames lowercase please due to case sensitivity on some systems.
-
-It's ok if we're not sure of the organization at first. We want to get started on writing together first and foremost. If you are doing an example with multiple files, please make a folder.

--- a/content/_footer.md
+++ b/content/_footer.md
@@ -1,0 +1,7 @@
++++
+title = ""
+description = ""
+hidden = true
++++
+
+[https://nteract.io](https://nteract.io)

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,7 +1,14 @@
 +++
 title = "Documentation"
 description = ""
-alwaysopen = true
 +++
 
-{{% children  %}}
+# nteract Documentation
+
+{{% notice info %}}
+Documentation is under construction.
+{{% /notice %}}
+
+## Contents
+
+{{% children style="card" depth="1" description="true" %}}

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,39 +1,7 @@
 +++
-title = "Contributor Guide"
+title = "Documentation"
 description = ""
-weight = 1
 alwaysopen = true
 +++
 
-## Welcome documentarians
-
-We're glad you are here. Excellent documentation empowers users and contributors.
-
-### Contributing content
-
-When adding information to the contents directory, the contents directory should
-include:
-
-* Markdown files
-* Notebooks!
-
-📝 Keep your filenames lowercase please due to case sensitivity on some systems.
-
-It's ok if we're not sure of the organization at first. We want to get started on writing together first and foremost. If you are doing an example with multiple files, please make a folder.
-
-### Building docs locally
-
-Initially, we will be using Hugo and its docdock theme as a git submodule.
-
-1. On a Mac, you can `brew install hugo`. On other systems, please follow the
-hugo installation steps.
-
-2. Get the documentation source or update the source.
-
-3. From the root of the repo, type `hugo server` to build and serve the docs
-   locally
-
-4. Navigate to `localhost:1313`
-
-
-
+{{% children  %}}

--- a/content/concepts/_index.md
+++ b/content/concepts/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Concepts"
+description = ""
+weight = 20
+alwaysopen = true
++++
+
+Concepts placeholder
+
+{{% children  %}}

--- a/content/concepts/_index.md
+++ b/content/concepts/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Concepts"
-description = ""
+description = "Documents that help you understand high level concepts about nteract."
 weight = 20
 alwaysopen = true
 +++

--- a/content/contributor-guides/_index.md
+++ b/content/contributor-guides/_index.md
@@ -1,10 +1,10 @@
 +++
 title = "Contributor Guides"
-description = ""
+description = "Welcome. These guides will help you contribute to nteract projects."
 weight = 50
 alwaysopen = true
 +++
 
 Welcome contributors.
 
-{{% children  %}}
+{{% children showhidden="true" %}}

--- a/content/contributor-guides/_index.md
+++ b/content/contributor-guides/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Contributor Guides"
+description = ""
+weight = 50
+alwaysopen = true
++++
+
+Welcome contributors.
+
+{{% children  %}}

--- a/content/contributor-guides/docs-contributor.md
+++ b/content/contributor-guides/docs-contributor.md
@@ -1,8 +1,8 @@
 +++
 title = "Documentation Contributor Guide"
-description = ""
-weight = 51
-alwaysopen = true
+description = "Learn how nteract works and how to contribute documentation."
+hidden = true
+weight = 1
 +++
 
 ## Welcome documentarians

--- a/content/contributor-guides/docs-contributor.md
+++ b/content/contributor-guides/docs-contributor.md
@@ -1,0 +1,39 @@
++++
+title = "Documentation Contributor Guide"
+description = ""
+weight = 51
+alwaysopen = true
++++
+
+## Welcome documentarians
+
+We're glad you are here. Excellent documentation empowers users and contributors.
+
+### Contributing content
+
+When adding information to the contents directory, the contents directory should
+include:
+
+* Markdown files
+* Notebooks!
+
+📝 Keep your filenames lowercase please due to case sensitivity on some systems.
+
+It's ok if we're not sure of the organization at first. We want to get started on writing together first and foremost. If you are doing an example with multiple files, please make a folder.
+
+### Building docs locally
+
+Initially, we will be using Hugo and its docdock theme as a git submodule.
+
+1. On a Mac, you can `brew install hugo`. On other systems, please follow the
+hugo installation steps.
+
+2. Get the documentation source or update the source.
+
+3. From the root of the repo, type `hugo server` to build and serve the docs
+   locally
+
+4. Navigate to `localhost:1313`
+
+
+

--- a/content/contributor-guides/docs-style.md
+++ b/content/contributor-guides/docs-style.md
@@ -1,0 +1,18 @@
++++
+title = "Documentation Style Guide"
+description = ""
+weight = 52
+alwaysopen = true
++++
+
+## Markup Language
+
+[Markdown](https://daringfireball.net/projects/markdown/syntax)
+
+## Documentation Tool
+
+[Hugo](https://gohugo.io/)
+
+## Theme
+
+[DocDock](http://docdock.netlify.com/)

--- a/content/contributor-guides/docs-style.md
+++ b/content/contributor-guides/docs-style.md
@@ -1,8 +1,8 @@
 +++
 title = "Documentation Style Guide"
 description = ""
-weight = 52
-alwaysopen = true
+hidden = true
+weight = 2
 +++
 
 ## Markup Language

--- a/content/installation-guides/_index.md
+++ b/content/installation-guides/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Installation Guides"
+description = ""
+weight = 10
+alwaysopen = true
++++
+
+Placeholder for installation guides

--- a/content/installation-guides/_index.md
+++ b/content/installation-guides/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Installation Guides"
-description = ""
+description = "Instructions for different systems and programming languages."
 weight = 10
 alwaysopen = true
 +++

--- a/content/style-guide/_index.md
+++ b/content/style-guide/_index.md
@@ -1,9 +1,0 @@
-+++
-title = "Style Guide"
-description = ""
-weight = 2
-alwaysopen = true
-+++
-
-
-<!-- Placeholder -->

--- a/content/user-guides/_index.md
+++ b/content/user-guides/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "User Guides"
-description = ""
+description = "Documents that help you get things done. 'How to' guides on a variety of topics."
 weight = 30
 alwaysopen = true
 +++

--- a/content/user-guides/_index.md
+++ b/content/user-guides/_index.md
@@ -1,0 +1,10 @@
++++
+title = "User Guides"
+description = ""
+weight = 30
+alwaysopen = true
++++
+
+Placeholder for user guides
+
+{{% children  %}}


### PR DESCRIPTION
Added a bit more structure around installation, concepts, user, and contributor guides.

<img width="1026" alt="screen shot 2018-07-27 at 2 00 26 pm" src="https://user-images.githubusercontent.com/2680980/43346485-206d6a22-91a6-11e8-8372-19cf89461dc0.png">
