### PR TITLE
Add link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # user-guide
+
 🏖 User written and user focused documentation for working with nteract! Join us! 
+
+Draft documentation: https://docs.nteract.io


### PR DESCRIPTION
Even though we are still working on the documentation style and content, we have deployed to docs.nteract.io